### PR TITLE
Add drop command to accept db name

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,16 @@ doctrine_migrations:
 #### You MUST  config the default connection and the default entity manager to use the main database. see the example above, for the complete configuration
 ####  You just need to update the config for the main EntityManager , Then the bundle will handle the rest for you.
 7. Add  the `TenantEntityManager` to your service or controller arguments.  
-8. Dispatch `SwitchDbEvent` with a custom value for your tenant db Identifier.
-    `Example new SwitchDbEvent(1)`
-9. You can switch between all tenants dbs just by dispatch the same event with different db identifier.
-10. Now your instance from `TenantEntityManager` is connected to the tenant db with Identifier = 1.
+8. Dispatch `SwitchDbEvent` with a custom value for your tenant db identifier or database name.
+    `Example new SwitchDbEvent(1)` or `new SwitchDbEvent('tenant_db_1')`
+9. You can switch between all tenants DBs just by dispatching the same event with a different identifier or name.
+10. Now your instance from `TenantEntityManager` is connected to the tenant DB with the given identifier.
 11. It's recommended having your tenant entities in a different directory from your Main entities.
 12. You can execute doctrine migration commands using our proxy commands for tenant database.
 
-        php bin/console tenant:database:create   # t:d:c  for short , To create non existing tenant dbs list 
+        php bin/console tenant:database:create   # t:d:c  for short , To create non existing tenant dbs list
+
+        php bin/console tenant:database:drop     # t:d:d  for short , To drop a tenant db by id or name
 
         php bin/console tenant:migration:diff    # t:m:d  for short , To generate migraiton for tenant db 
         

--- a/src/Command/DropDatabaseCommand.php
+++ b/src/Command/DropDatabaseCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Hakam\MultiTenancyBundle\Command;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Hakam\MultiTenancyBundle\Enum\DatabaseStatusEnum;
+use Hakam\MultiTenancyBundle\Services\DbConfigService;
+use Hakam\MultiTenancyBundle\Services\DbService;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+#[AsCommand(
+    name: 'tenant:database:drop',
+    description: 'Drop a tenant database by its identifier or name.',
+)]
+final class DropDatabaseCommand extends Command
+{
+    use CommandTrait;
+
+    public function __construct(
+        private readonly ManagerRegistry          $registry,
+        private readonly ContainerInterface       $container,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly DbService                $dbService,
+        private readonly DbConfigService          $dbConfigService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setAliases(['t:d:d'])
+            ->addArgument('dbIdentifier', InputArgument::REQUIRED, 'Tenant database identifier or name');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $dbIdentifier = $input->getArgument('dbIdentifier');
+
+        try {
+            $dbConfig = $this->dbConfigService->findDbConfig($dbIdentifier);
+            $this->dbService->dropDatabase($dbConfig->getDbName());
+            $dbConfig->setDatabaseStatus(DatabaseStatusEnum::DATABASE_NOT_CREATED);
+            $this->registry->getManager()->persist($dbConfig);
+            $this->registry->getManager()->flush();
+            $output->writeln(sprintf('Database %s dropped successfully.', $dbConfig->getDbName()));
+            return Command::SUCCESS;
+        } catch (\Throwable $e) {
+            $output->writeln($e->getMessage());
+            return Command::FAILURE;
+        }
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -35,6 +35,14 @@
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Hakam\MultiTenancyBundle\Services\DbService"/>
         </service>
+        <service id="Hakam\MultiTenancyBundle\Command\DropDatabaseCommand">
+            <tag name="console.command"/>
+            <argument type="service" id="Doctrine\Common\Persistence\ManagerRegistry"/>
+            <argument type="service" id="service_container"/>
+            <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Hakam\MultiTenancyBundle\Services\DbService"/>
+            <argument type="service" id="Hakam\MultiTenancyBundle\Services\DbConfigService"/>
+        </service>
         <service id="Hakam\MultiTenancyBundle\Command\MigrateCommand">
             <tag name="console.command"/>
             <argument type="service" id="Doctrine\Common\Persistence\ManagerRegistry"/>

--- a/src/Services/DbConfigService.php
+++ b/src/Services/DbConfigService.php
@@ -20,10 +20,28 @@ class DbConfigService
 
     public function findDbConfig(?string $identifier): TenantDbConfigurationInterface
     {
-        $dbConfigObject = $identifier ?  $this->entityRepository->findOneBy([$this->dbIdentifier => $identifier]) :
-            $this->entityRepository->findOneBy(['databaseStatus' => DatabaseStatusEnum::DATABASE_MIGRATED]);
+        if ($identifier) {
+            $dbConfigObject = $this->entityRepository->findOneBy([
+                $this->dbIdentifier => $identifier,
+            ]);
+
+            // Fallback to dbName search if not found
+            if (null === $dbConfigObject) {
+                $dbConfigObject = $this->entityRepository->findOneBy(['dbName' => $identifier]);
+            }
+        } else {
+            $dbConfigObject = $this->entityRepository->findOneBy([
+                'databaseStatus' => DatabaseStatusEnum::DATABASE_MIGRATED,
+            ]);
+        }
+
         if (null === $dbConfigObject) {
-            throw new \RuntimeException(sprintf('Tenant db repository " %s " returns NULL for identifier " %s = %s " ', get_class($this->entityRepository), $this->dbIdentifier, $identifier));
+            throw new \RuntimeException(sprintf(
+                'Tenant db repository "%s" returns NULL for identifier "%s = %s" ',
+                get_class($this->entityRepository),
+                $this->dbIdentifier,
+                $identifier
+            ));
         }
 
         if (!$dbConfigObject instanceof TenantDbConfigurationInterface) {


### PR DESCRIPTION
## Summary
- allow dropping tenant db using id or db name
- support passing db names to SwitchDbEvent
- update docs for new functionality

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683f552efd78832bb5d67ad67cdbfa11