### PR TITLE
Improve logging for tenant DB switching

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -18,6 +18,7 @@
             <argument type="service" id="service_container"/>
             <argument type="service" id="hakam_db_config.service"/>
             <argument type="string">%env(DATABASE_URL)%</argument>
+            <argument type="service" id="logger"/>
         </service>
 
         <service id="Hakam\MultiTenancyBundle\Command\DiffCommand">

--- a/tests/Functional/MultiTenancyBundleTestingKernel.php
+++ b/tests/Functional/MultiTenancyBundleTestingKernel.php
@@ -33,6 +33,7 @@ class MultiTenancyBundleTestingKernel extends Kernel
     {
         $loader->load(function (ContainerBuilder $container) {
             $container->register('annotation_reader', AnnotationReader::class);
+            $container->register('logger', \Psr\Log\NullLogger::class);
             
             // Configure Doctrine
             $container->loadFromExtension('doctrine', [

--- a/tests/Unit/EventListener/DbSwitchEventListenerTest.php
+++ b/tests/Unit/EventListener/DbSwitchEventListenerTest.php
@@ -12,6 +12,7 @@ use Symfony\Bridge\Doctrine\ManagerRegistry;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Hakam\MultiTenancyBundle\Services\DbConfigService;
 use Hakam\MultiTenancyBundle\Enum\DriverTypeEnum;
+use Psr\Log\LoggerInterface;
 
 class DbSwitchEventListenerTest extends TestCase
 {
@@ -20,9 +21,12 @@ class DbSwitchEventListenerTest extends TestCase
         // mock the necessary dependencies
         $mockContainer = $this->createMock(ContainerInterface::class);
         $mockDbConfigService = $this->createMock(DbConfigService::class);
+        $mockLogger = $this->createMock(LoggerInterface::class);
+        $mockLogger->expects($this->exactly(2))
+            ->method('info');
 
         // create a test instance of the listener
-        $listener = new DbSwitchEventListener($mockContainer, $mockDbConfigService, 'test_database_url');
+        $listener = new DbSwitchEventListener($mockContainer, $mockDbConfigService, 'test_database_url', $mockLogger);
 
         // create a test event
         $testDbIndex = 1;


### PR DESCRIPTION
## Summary
- add `LoggerInterface` to `DbSwitchEventListener`
- log before and after switching tenant connection
- wire logger service in XML configuration
- register a NullLogger in tests
- update unit tests for logging

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5a8d4a34832ba16c3feb3974e8f9